### PR TITLE
fix: add auxiliary process detection for Unity on macOS and Windows

### DIFF
--- a/src/launch.ts
+++ b/src/launch.ts
@@ -238,6 +238,14 @@ function extractProjectPath(command: string): string | undefined {
   return trimmed;
 }
 
+const isUnityAuxiliaryProcess = (command: string): boolean => {
+  const normalizedCommand: string = command.toLowerCase();
+  if (normalizedCommand.includes("-batchmode")) {
+    return true;
+  }
+  return normalizedCommand.includes("assetimportworker");
+};
+
 async function listUnityProcessesMac(): Promise<UnityProcessInfo[]> {
   let stdout = "";
   try {
@@ -269,6 +277,9 @@ async function listUnityProcessesMac(): Promise<UnityProcessInfo[]> {
 
     const command = match[2] ?? "";
     if (!UNITY_EXECUTABLE_PATTERN_MAC.test(command)) {
+      continue;
+    }
+    if (isUnityAuxiliaryProcess(command)) {
       continue;
     }
 
@@ -328,6 +339,9 @@ async function listUnityProcessesWindows(): Promise<UnityProcessInfo[]> {
     }
 
     if (!UNITY_EXECUTABLE_PATTERN_WINDOWS.test(command)) {
+      continue;
+    }
+    if (isUnityAuxiliaryProcess(command)) {
       continue;
     }
 


### PR DESCRIPTION
## Summary
Avoid counting Unity auxiliary processes as running Editor instances. This prevents false positives when Unity spawns background processes (e.g., AssetImportWorker or batchmode runs) and ensures we only consider real Editor sessions bound to a project.

## Changes
- Add `isUnityAuxiliaryProcess(command)` to detect auxiliary processes by command line
  - Treat `-batchmode` as auxiliary
  - Treat `AssetImportWorker` as auxiliary
- Apply the filter to both macOS and Windows process listings in `listUnityProcessesMac` and `listUnityProcessesWindows`

## Motivation
Some environments run Unity in batch mode or start `AssetImportWorker` in the background. These processes should not be treated as active Editor sessions tied to a project, otherwise project detection and launch orchestration can behave incorrectly.

## Testing
- macOS
  - Verified that real Editor processes are detected
  - Verified that `-batchmode` processes are ignored
  - Verified that `AssetImportWorker` processes are ignored
- Windows
  - Verified filtering logic on process enumeration path

## Risks & Rollback
- Risk: Over-filtering if future Unity auxiliary processes use different names/flags
- Mitigation: The checks are conservative and can be extended based on feedback
- Rollback: Revert this PR if it unintentionally filters legitimate Editor sessions

## Checklist
- [x] No breaking API changes
- [x] Behavior aligned on macOS and Windows
- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced process detection to filter auxiliary Unity processes, improving accuracy when identifying running instances on macOS and Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->