### PR TITLE
fix: add build step to npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish-on-release.yml
+++ b/.github/workflows/npm-publish-on-release.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Install
         if: ${{ steps.plan.outputs.has_release == 'true' && steps.plan.outputs.already != 'true' }}
         run: npm ci
+      - name: Build
+        if: ${{ steps.plan.outputs.has_release == 'true' && steps.plan.outputs.already != 'true' }}
+        run: npm run build
       - name: Publish
         if: ${{ steps.plan.outputs.has_release == 'true' && steps.plan.outputs.already != 'true' }}
         run: npm publish --access public


### PR DESCRIPTION
 ## Summary
  - Add missing `npm run build` step to the npm publish workflow
  - This fixes the issue where packages were published without the `dist/` directory, causing
  `npx launch-unity` to fail with "command not found"

  ## Root Cause
  The workflow ran `npm ci` to install dependencies but skipped the build step before `npm
  publish`. Since `dist/` is in `.gitignore`, the published package contained only README files
  and package.json, missing the actual JavaScript executables.

  ## Test plan
  - [ ] Merge this PR
  - [ ] Create a new release (v0.6.1)
  - [ ] Verify `npx launch-unity` works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated release workflow to include a build validation step, ensuring compiled artifacts are generated during the publish process for enhanced release reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->