### PR TITLE
feat: add -a and -f flags for Unity Hub registration

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -27,12 +27,17 @@ launch-unity [OPTIONS] [PROJECT_PATH] [PLATFORM] [-- UNITY_ARGS...]
 # オプション
 #   -h, --help      ヘルプを表示
 #   -r, --restart   Unityを再起動
+#   -a, -u, --add-unity-hub, --unity-hub-entry
+#                   Unity Hub に登録（Unityは起動しない）
+#   -f, --favorite  Unity Hub にお気に入りとして登録（Unityは起動しない）
 
 # 例
 npx launch-unity                   # プロジェクトを探索して開く
 npx launch-unity /path/to/Proj     # 指定プロジェクトを開く
 npx launch-unity /path Android     # ビルドターゲットを指定
 npx launch-unity -r                # Unityを再起動
+npx launch-unity -a                # Unity Hub に登録のみ（Unityは起動しない）
+npx launch-unity -f                # Unity Hub にお気に入り登録（Unityは起動しない）
 npx launch-unity . -- -batchmode -quit -nographics -logFile -  # Unity引数を渡す
 npx launch-unity /path Android -- -executeMethod My.Build.Entry
 ```

--- a/README.md
+++ b/README.md
@@ -27,12 +27,17 @@ launch-unity [OPTIONS] [PROJECT_PATH] [PLATFORM] [-- UNITY_ARGS...]
 # Options
 #   -h, --help      Show help
 #   -r, --restart   Kill running Unity and restart
+#   -a, -u, --add-unity-hub, --unity-hub-entry
+#                   Register to Unity Hub (does not launch Unity)
+#   -f, --favorite  Register to Unity Hub as favorite (does not launch Unity)
 
 # Examples
 npx launch-unity                   # Search for project and open
 npx launch-unity /path/to/Proj     # Open specific project
 npx launch-unity /path Android     # Specify build target
 npx launch-unity -r                # Restart Unity
+npx launch-unity -a                # Register to Unity Hub only (does not launch Unity)
+npx launch-unity -f                # Register as favorite (does not launch Unity)
 npx launch-unity . -- -batchmode -quit -nographics -logFile -  # Pass Unity args
 npx launch-unity /path Android -- -executeMethod My.Build.Entry
 ```


### PR DESCRIPTION
## Summary
Added dedicated flags for Unity Hub registration without launching Unity.

## Changes
- `-a` / `-u` / `--add-unity-hub` / `--unity-hub-entry`: Register to Unity Hub (does not launch Unity)
- `-f` / `--favorite`: Register as favorite in Unity Hub (does not launch Unity)
- Updated README (EN/JA) with new flags documentation
- Fixed path casing issue when registering to Unity Hub

## Usage
```bash
# Register to Unity Hub only
launch-unity -a

# Register as favorite
launch-unity -f
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-a`/`--add-unity-hub` option to register projects in Unity Hub without launching Unity
  * Added `-f`/`--favorite` option to mark projects as favorites in Unity Hub

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->