### PR TITLE
chore: add minimum-release-age to prevent supply chain attacks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,6 @@
 # Disable automatic script execution like postinstall
 ignore-scripts=true
 
+# Delay installing newly published packages to mitigate supply chain attacks
+minimum-release-age=3d
+


### PR DESCRIPTION
## Summary
Added `minimum-release-age=3d` setting to `.npmrc` as an additional layer of defense against supply chain attacks like Shai-Hulud 2.0.

## Changes
- Added `minimum-release-age=3d` to `.npmrc`
  - This delays installing newly published package versions by 3 days
  - Gives time for malicious packages to be detected and removed before installation

## Security Layers (Current Status)
| Layer | Status |
|-------|--------|
| minimum-release-age | ✅ Added |
| ignore-scripts | ✅ Already configured |
| npm audit (SCA) | ✅ In CI |
| lockfile-lint | ✅ In CI |
| Pinned versions | ✅ No ^ or ~ used |

## Reference
- https://zenn.dev/hand_dot/articles/04542a91bc432e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package installation configuration to introduce a 3-day delay before installing newly released packages while maintaining existing script execution settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->