### PR TITLE
feat: add launch-unity update (self-update)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -44,6 +44,9 @@ npx launch-unity /path Android -- -executeMethod My.Build.Entry
 
 # 自己更新（npmグローバルインストール向け）
 launch-unity update
+
+# `update` という名前のディレクトリを開きたい場合は明示する
+launch-unity ./update
 ```
 
 指定した Unity プロジェクトの `ProjectSettings/ProjectVersion.txt` から必要な Unity Editor のバージョンを読み取り、

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ npx launch-unity /path Android -- -executeMethod My.Build.Entry
 
 # Self update (for npm global install)
 launch-unity update
+
+# If you have a project directory named "update", specify it explicitly
+launch-unity ./update
 ```
 
 A TypeScript CLI for macOS and Windows that reads the required Unity Editor version from

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -318,7 +318,7 @@ Usage:
 Open a Unity project with the matching Unity Editor version installed by Unity Hub.
 
 Arguments:
-  PROJECT_PATH  Optional. Defaults to current directory
+  PROJECT_PATH  Optional. If omitted, searches under the current directory (see --max-depth)
   PLATFORM      Optional. Passed to Unity as -buildTarget (e.g., StandaloneOSX, Android, iOS)
 
 Forwarding:


### PR DESCRIPTION
- Added `launch-unity update` to enable global npm updates.
- Added notes to `--help` and README (English/Japanese).

## 動作
- `launch-unity update` checks the latest version on npm and, if necessary, runs the following:

    `npm install -g launch-unity@LATEST --ignore-scripts`

- If it fails due to insufficient permissions, it will guide the user to use the command with `sudo` for macOS and then exit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a self-update command so users can update the tool from the CLI when installed globally via npm; shows current and latest versions and reports update status.

* **Documentation**
  * Updated README with usage syntax, examples, and a dedicated "Self update" section including permission guidance for common environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->