### PR TITLE
fix: remove Library folder check from Unity project detection

### DIFF
--- a/src/launch.ts
+++ b/src/launch.ts
@@ -736,12 +736,7 @@ const EXCLUDED_DIR_NAMES = new Set<string>([
 
 function isUnityProjectRoot(candidateDir: string): boolean {
   const versionFile: string = join(candidateDir, "ProjectSettings", "ProjectVersion.txt");
-  const hasVersion: boolean = existsSync(versionFile);
-  if (!hasVersion) {
-    return false;
-  }
-  const libraryDir: string = join(candidateDir, "Library");
-  return existsSync(libraryDir);
+  return existsSync(versionFile);
 }
 
 function listSubdirectoriesSorted(dir: string): string[] {


### PR DESCRIPTION
## Summary
- Remove unnecessary Library folder check from `isUnityProjectRoot` function
- Unity projects are now detected by `ProjectSettings/ProjectVersion.txt` only
- This allows freshly cloned projects (without Library folder) to be recognized

## Test plan
- [ ] Run `launch-unity` in a freshly cloned Unity project directory
- [ ] Verify the project is detected and launched correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined project detection logic by simplifying the verification process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->