### PR TITLE
fix: startup progress appears immediately after Unity Hub launch options

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "node dist/launch.js",
-    "test": "npm run build && node --test test/**/*.test.mjs",
+    "test": "npm run build && node --test",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "node dist/launch.js",
+    "test": "npm run build && node --test test/**/*.test.mjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/src/launchUnityProcess.ts
+++ b/src/launchUnityProcess.ts
@@ -32,7 +32,12 @@ export function launchUnityProcess(
 
     const handleSpawn = (): void => {
       child.removeListener("error", handleError);
-      onSpawned();
+      try {
+        onSpawned();
+      } catch (error) {
+        reject(error);
+        return;
+      }
       child.unref();
       resolve();
     };

--- a/src/launchUnityProcess.ts
+++ b/src/launchUnityProcess.ts
@@ -1,0 +1,43 @@
+/**
+ * Coordinates Unity process launch so callers can react only after the child
+ * process has actually started.
+ */
+
+import { spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+
+export type SpawnProcess = typeof spawn;
+
+export function launchUnityProcess(
+  spawnProcess: SpawnProcess,
+  unityPath: string,
+  args: string[],
+  onSpawned: () => void,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const child: ChildProcess = spawnProcess(unityPath, args, {
+      stdio: "ignore",
+      detached: true,
+      // Git Bash (MSYS) rewrites Windows-style paths unless the launch opts out.
+      env: {
+        ...process.env,
+        MSYS_NO_PATHCONV: "1",
+      },
+    });
+
+    const handleError = (error: Error): void => {
+      child.removeListener("spawn", handleSpawn);
+      reject(new Error(`Failed to launch Unity: ${error.message}`));
+    };
+
+    const handleSpawn = (): void => {
+      child.removeListener("error", handleError);
+      onSpawned();
+      child.unref();
+      resolve();
+    };
+
+    child.once("error", handleError);
+    child.once("spawn", handleSpawn);
+  });
+}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -47,6 +47,7 @@ const UNITY_LOCKFILE_NAME = "UnityLockfile";
 const TEMP_DIRECTORY_NAME = "Temp";
 const ASSETS_DIRECTORY_NAME = "Assets";
 const RECOVERY_DIRECTORY_NAME = "_Recovery";
+const UNITY_STARTUP_WAIT_MESSAGE = "Waiting for Unity to finish starting...";
 
 export function parseArgs(argv: string[]): LaunchOptions {
   const args: string[] = argv.slice(2);
@@ -925,6 +926,12 @@ export type OrchestrateResult =
   | { action: "killed-and-launched"; projectPath: string; unityVersion: string }
   | { action: "hub-updated"; projectPath: string; unityVersion: string };
 
+export function shouldWaitForUnityStartup(
+  action: OrchestrateResult["action"],
+): action is "launched" | "killed-and-launched" {
+  return action === "launched" || action === "killed-and-launched";
+}
+
 export async function orchestrateLaunch(options: OrchestrateOptions): Promise<OrchestrateResult> {
   if (options.quit && options.restart) {
     throw new Error("--quit and --restart cannot be used together.");
@@ -1003,7 +1010,6 @@ export async function orchestrateLaunch(options: OrchestrateOptions): Promise<Or
     unityVersion,
   };
   await launch(resolved);
-  await waitForLockfile(resolvedProjectPath);
 
   // Hub timestamp update is non-critical external I/O; failure should not block after successful launch
   const now: Date = new Date();
@@ -1015,6 +1021,11 @@ export async function orchestrateLaunch(options: OrchestrateOptions): Promise<Or
   }
 
   const action: "killed-and-launched" | "launched" = isRestart ? "killed-and-launched" : "launched";
+  if (shouldWaitForUnityStartup(action)) {
+    console.log(UNITY_STARTUP_WAIT_MESSAGE);
+    await waitForLockfile(resolvedProjectPath);
+  }
+
   return { action, projectPath: resolvedProjectPath, unityVersion };
 }
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -9,6 +9,7 @@ import { rm } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 
+import { launchUnityProcess } from "./launchUnityProcess.js";
 import { ensureProjectEntryAndUpdate, updateLastModifiedIfExists, getProjectCliArgs, parseCliArgs, groupCliArgs } from "./unityHub.js";
 
 export type LaunchOptions = {
@@ -879,34 +880,8 @@ export async function launch(opts: LaunchResolvedOptions): Promise<void> {
     args.push(...unityArgs);
   }
 
-  // Print the wait message before spawn resolves because Unity startup can take
-  // noticeable time after the launch options line, which otherwise looks like a stall.
-  console.log(UNITY_STARTUP_WAIT_MESSAGE);
-
-  return new Promise<void>((resolve, reject) => {
-    const child = spawn(unityPath, args, {
-      stdio: "ignore",
-      detached: true,
-      // Git Bash (MSYS) がWindows パスをUnix 形式に自動変換するのを防ぐ
-      env: {
-        ...process.env,
-        MSYS_NO_PATHCONV: "1",
-      },
-    });
-
-    const handleError = (error: Error): void => {
-      child.removeListener("spawn", handleSpawn);
-      reject(new Error(`Failed to launch Unity: ${error.message}`));
-    };
-
-    const handleSpawn = (): void => {
-      child.removeListener("error", handleError);
-      child.unref();
-      resolve();
-    };
-
-    child.once("error", handleError);
-    child.once("spawn", handleSpawn);
+  return launchUnityProcess(spawn, unityPath, args, () => {
+    console.log(UNITY_STARTUP_WAIT_MESSAGE);
   });
 }
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -879,6 +879,10 @@ export async function launch(opts: LaunchResolvedOptions): Promise<void> {
     args.push(...unityArgs);
   }
 
+  // Print the wait message before spawn resolves because Unity startup can take
+  // noticeable time after the launch options line, which otherwise looks like a stall.
+  console.log(UNITY_STARTUP_WAIT_MESSAGE);
+
   return new Promise<void>((resolve, reject) => {
     const child = spawn(unityPath, args, {
       stdio: "ignore",
@@ -1022,7 +1026,6 @@ export async function orchestrateLaunch(options: OrchestrateOptions): Promise<Or
 
   const action: "killed-and-launched" | "launched" = isRestart ? "killed-and-launched" : "launched";
   if (shouldWaitForUnityStartup(action)) {
-    console.log(UNITY_STARTUP_WAIT_MESSAGE);
     await waitForLockfile(resolvedProjectPath);
   }
 

--- a/test/launch-unity-process.test.mjs
+++ b/test/launch-unity-process.test.mjs
@@ -1,0 +1,67 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type -- node:test fixtures in .mjs cannot use TypeScript-style return annotations. */
+
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+
+import { launchUnityProcess } from "../dist/launchUnityProcess.js";
+
+class FakeChildProcess extends EventEmitter {
+  constructor() {
+    super();
+    this.unrefCallCount = 0;
+  }
+
+  unref() {
+    this.unrefCallCount += 1;
+  }
+}
+
+test("launchUnityProcess runs onSpawned only after the child process spawns", async () => {
+  const child = new FakeChildProcess();
+  const notifications = [];
+
+  const spawnProcess = (unityPath, args, options) => {
+    assert.equal(unityPath, "/Applications/Unity");
+    assert.deepEqual(args, ["-projectPath", "/tmp/project"]);
+    assert.equal(options.env.MSYS_NO_PATHCONV, "1");
+    queueMicrotask(() => {
+      child.emit("spawn");
+    });
+    return child;
+  };
+
+  await launchUnityProcess(
+    spawnProcess,
+    "/Applications/Unity",
+    ["-projectPath", "/tmp/project"],
+    () => {
+      notifications.push("waiting");
+    },
+  );
+
+  assert.deepEqual(notifications, ["waiting"]);
+  assert.equal(child.unrefCallCount, 1);
+});
+
+test("launchUnityProcess does not run onSpawned when the child process errors immediately", async () => {
+  const child = new FakeChildProcess();
+  const notifications = [];
+
+  const spawnProcess = () => {
+    queueMicrotask(() => {
+      child.emit("error", new Error("EACCES"));
+    });
+    return child;
+  };
+
+  await assert.rejects(
+    launchUnityProcess(spawnProcess, "/Applications/Unity", ["-projectPath", "/tmp/project"], () => {
+      notifications.push("waiting");
+    }),
+    /Failed to launch Unity: EACCES/,
+  );
+
+  assert.deepEqual(notifications, []);
+  assert.equal(child.unrefCallCount, 0);
+});

--- a/test/launch-unity-process.test.mjs
+++ b/test/launch-unity-process.test.mjs
@@ -65,3 +65,23 @@ test("launchUnityProcess does not run onSpawned when the child process errors im
   assert.deepEqual(notifications, []);
   assert.equal(child.unrefCallCount, 0);
 });
+
+test("launchUnityProcess rejects when onSpawned throws", async () => {
+  const child = new FakeChildProcess();
+
+  const spawnProcess = () => {
+    queueMicrotask(() => {
+      child.emit("spawn");
+    });
+    return child;
+  };
+
+  await assert.rejects(
+    launchUnityProcess(spawnProcess, "/Applications/Unity", ["-projectPath", "/tmp/project"], () => {
+      throw new Error("progress callback failed");
+    }),
+    /progress callback failed/,
+  );
+
+  assert.equal(child.unrefCallCount, 0);
+});

--- a/test/startup-wait.test.mjs
+++ b/test/startup-wait.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldWaitForUnityStartup } from "../dist/lib.js";
+
+test("should wait for Unity startup only after a new launch", () => {
+  assert.equal(shouldWaitForUnityStartup("launched"), true);
+  assert.equal(shouldWaitForUnityStartup("killed-and-launched"), true);
+  assert.equal(shouldWaitForUnityStartup("focused"), false);
+  assert.equal(shouldWaitForUnityStartup("quit"), false);
+  assert.equal(shouldWaitForUnityStartup("hub-updated"), false);
+});


### PR DESCRIPTION
## Summary
- Show launch progress as soon as Unity Hub launch options are printed
- Remove the silent pause before startup feedback appears

## User Impact
- `launch-unity` no longer looks stalled after `Unity Hub launch options: ...` is printed
- Users see startup progress immediately while the spawned Unity process is still settling

## Changes
- Print the startup wait message before the spawned Unity process finishes acknowledging launch
- Keep the lockfile wait in the launch flow without duplicating the startup message
- Add a regression test for launch actions that should wait for Unity startup

## Verification
- npm run lint
- npm run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup status message to improve visibility of post-launch initialization latency and provide real-time feedback during the launch process.

* **Tests**
  * Introduced automated testing infrastructure with npm test script to validate startup orchestration and launch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->